### PR TITLE
add shebang to the top of run.py

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
 {
 	"authors": ["AXAz0r", "Awakening", "Valeth"],
-	"contributors": ["Mirai", "Chaeldar"]
+	"contributors": ["Mirai", "Chaeldar", "mralext20"]
 }

--- a/run.py
+++ b/run.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 
 import sigma


### PR DESCRIPTION
allows the executable to be called by `./run.py` instead of `python3 run.py`